### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/testwitiq15/54f1178b-00d0-4182-b3b8-96246d32e522/e6625837-1e10-455c-85cb-2485880829f8/_apis/work/boardbadge/49d71be8-9195-4d83-ab22-f7eb6f59e43d)](https://dev.azure.com/testwitiq15/54f1178b-00d0-4182-b3b8-96246d32e522/_boards/board/t/e6625837-1e10-455c-85cb-2485880829f8/Microsoft.RequirementCategory)
 # Azure DevOps Web API clients and contracts
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/testwitiq15/54f1178b-00d0-4182-b3b8-96246d32e522/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.